### PR TITLE
Add test to ensure the dbt-core test dependency is correct

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1866,6 +1866,14 @@ optional = false
 python-versions = ">=3.6"
 
 [[package]]
+name = "types-toml"
+version = "0.10.7"
+description = "Typing stubs for toml"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "typing-extensions"
 version = "3.10.0.2"
 description = "Backported and Experimental Type Hints for Python 3.5+"
@@ -1974,7 +1982,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7.1,<4.0"
-content-hash = "6fbff3aa9d569a21d0e5ee1aa3198aa349051706956192f791adef155dc94a20"
+content-hash = "c3753ca7a2e5a8c076053563877ac7670150c7d33d6b1fa67663b33d71cfe16f"
 
 [metadata.files]
 agate = [
@@ -3457,6 +3465,10 @@ typed-ast = [
     {file = "typed_ast-1.5.3-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:8831479695eadc8b5ffed06fdfb3e424adc37962a75925668deeb503f446c0a3"},
     {file = "typed_ast-1.5.3-cp39-cp39-win_amd64.whl", hash = "sha256:20d5118e494478ef2d3a2702d964dae830aedd7b4d3b626d003eea526be18718"},
     {file = "typed_ast-1.5.3.tar.gz", hash = "sha256:27f25232e2dd0edfe1f019d6bfaaf11e86e657d9bdb7b0956db95f560cceb2b3"},
+]
+types-toml = [
+    {file = "types-toml-0.10.7.tar.gz", hash = "sha256:a567fe2614b177d537ad99a661adc9bfc8c55a46f95e66370a4ed2dd171335f9"},
+    {file = "types_toml-0.10.7-py3-none-any.whl", hash = "sha256:05a8da4bfde2f1ee60e90c7071c063b461f74c63a9c3c1099470c08d6fa58615"},
 ]
 typing-extensions = [
     {file = "typing_extensions-3.10.0.2-py2-none-any.whl", hash = "sha256:d8226d10bc02a29bcc81df19a26e56a9647f8b0a6d4a83924139f4a8b01f17b7"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ pytest-dotenv = "*"
 isort = "^5.10.1"
 bandit = "^1.7.4"
 toml = "^0.10.2"
+types-toml = "^0.10.7"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/test/unit/test_dependencies.py
+++ b/test/unit/test_dependencies.py
@@ -1,24 +1,25 @@
-from distutils import core
-
-
 import pathlib
 import re
+
 import toml
 
-def test_dbt_core_version():
+
+def test_dbt_core_version() -> None:
     repo_root = pathlib.Path(__file__).parent.parent.parent
 
     dbt_version_file = repo_root / "dbt" / "adapters" / "layer_bigquery" / "__version__.py"
     with open(dbt_version_file) as f:
         content = f.read()
         match = re.search('version = "(.*)"', content)
-        dbt_version = match.group(1)
+        if match:
+            dbt_version = match.group(1)
+        else:
+            raise Exception("Failed to get version")
 
     pyproject_file = repo_root / "pyproject.toml"
 
     with open(pyproject_file) as f:
         pyproject = toml.load(f)
-        dbt_core_version = pyproject['tool']['poetry']['dependencies']['dbt-core']
+        dbt_core_version = pyproject["tool"]["poetry"]["dependencies"]["dbt-core"]
 
     assert dbt_core_version == dbt_version
-


### PR DESCRIPTION
Prior to using poetry, setup.py used to dynamically load the `dbt-core` dependency version from the version of our `dbt` package. As this is not possible with poetry, create a test that ensures the versions match.

fixes https://linear.app/layer/issue/LAY-3025/ensure-version-under-dbt-matches-dbt-core-dependency