### PR TITLE
Fix wrong module

### DIFF
--- a/layer_dbt/dbt/sql_parser.py
+++ b/layer_dbt/dbt/sql_parser.py
@@ -23,7 +23,7 @@ class LayerSQL(object):
 
 class LayerSQLParser(object):
     @staticmethod
-    def _clean_sql_tokens(tokens: List[sqlparse.Token]) -> List[sqlparse.Token]:
+    def _clean_sql_tokens(tokens: List[sqlparse.sql.Token]) -> List[sqlparse.sql.Token]:
         """
         Removes whitespace and semicolon punctuation tokens
         """


### PR DESCRIPTION
Fix wrong module on type hint which was leading to an error below:

```
(dbt-layer-bigquery-0G4KAP-N-py3.8) (base) emindemirci@Emins-MacBook-Pro titanic % dbt run
14:16:26  Encountered an error:
module 'sqlparse' has no attribute 'Token'
```