### PR TITLE
Allow usage of conda

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,17 @@
 INSTALL_STAMP := .install.stamp
 POETRY := $(shell command -v poetry 2> /dev/null)
+IN_VENV := $(shell echo $(CONDA_DEFAULT_ENV)$(CONDA_PREFIX)$(VIRTUAL_ENV))
 
 .DEFAULT_GOAL:=help
 
 install: $(INSTALL_STAMP) ## Install dependencies
 $(INSTALL_STAMP): pyproject.toml poetry.lock
 	@if [ -z $(POETRY) ]; then echo "Poetry could not be found. See https://python-poetry.org/docs/"; exit 2; fi
+ifdef IN_VENV
+	$(POETRY) install
+else
 	$(POETRY) install --remove-untracked
+endif
 	touch $(INSTALL_STAMP)
 
 .PHONY: test


### PR DESCRIPTION
If already in a venv, `poetry` will not create its own venv and we can't force it to. In this scenario we can install with `--remove-untracked` because poetry will uninstall itself