### PR TITLE
Make import absolute to avoid import error

### DIFF
--- a/dbt/adapters/layer_bigquery/impl.py
+++ b/dbt/adapters/layer_bigquery/impl.py
@@ -1,8 +1,7 @@
 from dbt.adapters.bigquery.impl import BigQueryAdapter  # type:ignore
 
 from common.adapter import LayerAdapter
-
-from .connections import LayerBigQueryConnectionManager
+from dbt.adapters.layer_bigquery.connections import LayerBigQueryConnectionManager
 
 
 class LayerBigQueryAdapter(LayerAdapter, BigQueryAdapter):


### PR DESCRIPTION
The build on my system is failing with
```
/home/maasg/.poetry/bin/poetry run black --check . --diff
All done! ✨ 🍰 ✨
14 files would be left unchanged.
/home/maasg/.poetry/bin/poetry run flake8 .
/home/maasg/.poetry/bin/poetry run pylint  --recursive yes .
************* Module layer_bigquery.impl
dbt/adapters/layer_bigquery/impl.py:5:0: E0401: Unable to import 'layer_bigquery.connections' (import-error)
```
After trying changing the python version and cleaning up the env, I'm giving up on external changes.
This small diff fixes the error for me. Can we live with it?