### PR TITLE
Add a check that the package works without the dev dependencies

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -4,6 +4,26 @@ on:
     branches-ignore: ['main']
 
 jobs:
+  check-package-loads:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Setup poetry
+        uses: abatilo/actions-poetry@v2.0.0
+        with:
+          poetry-version: 1.1.13
+      - name: Cache poetry virtualenvs
+        uses: actions/cache@v3
+        with:
+          path: /home/runner/.cache/pypoetry/virtualenvs
+          key: poetry-venvs-no-dev-${{ runner.os }}-3.8-${{ hashFiles('poetry.lock') }}
+          restore-keys: poetry-vevns-no-dev-${{ runner.os }}-3.8-
+      - name: Check package loads without dev dependencies
+        run: make check-package-loads
+
   check-lockfile:
     runs-on: ubuntu-18.04
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,8 +27,29 @@ jobs:
           restore-keys: poetry-venvs-${{ runner.os }}-${{ matrix.python-version }}-
       - name: Run check
         run: make check
+
+  check-package-loads:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Setup poetry
+        uses: abatilo/actions-poetry@v2.0.0
+        with:
+          poetry-version: 1.1.13
+      - name: Cache poetry virtualenvs
+        uses: actions/cache@v3
+        with:
+          path: /home/runner/.cache/pypoetry/virtualenvs
+          key: poetry-venvs-no-dev-${{ runner.os }}-3.8-${{ hashFiles('poetry.lock') }}
+          restore-keys: poetry-vevns-no-dev-${{ runner.os }}-3.8-
+      - name: Check package loads without dev dependencies
+        run: make check-package-loads
+
   publish:
-    needs: [ check ]
+    needs: [ check , check-package-loads]
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,16 @@ lint: $(INSTALL_STAMP) ## Run all linters
 .PHONY: check
 check: test lint ## Run test and lint
 
+.PHONY: check-package-loads
+check-package-loads: ## Check that we can load the package without the dev dependencies
+	@rm -f $(INSTALL_STAMP)
+ifdef IN_VENV
+	$(POETRY) install --no-dev
+else
+	$(POETRY) install --no-dev --remove-untracked
+endif
+	$(POETRY) run python -c "import dbt"
+
 .PHONY: publish 
 publish: ## Publish to PyPi - should only run in CI
 	@test $${PATCH_VERSION?PATCH_VERSION expected}


### PR DESCRIPTION
If we have a certain python dependency and add it to the dev dependencis instead of the generic dependencies, all the tests would pass, but the package we release will be broken as it won't have all dependencies specified.

To guard against this, add a simple check that loads the package with only the non-dev dependencies installed.